### PR TITLE
Test automation

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -288,7 +288,7 @@ class Emulator:
             pygame.display.flip()
         return True
     
-    def capture_screenshot(self, screenshot_path: str = None) -> bool:
+    def capture_screenshot(self, screenshot_path: str = None):
         image_data = np.array(self.console.bus.ppu.getScreen())
         if image_data.shape[2] == 3:
             image_data = cv2.cvtColor(image_data, cv2.COLOR_BGR2RGB)
@@ -300,7 +300,7 @@ class Emulator:
 
         image = Image.fromarray(image_data)
         image.save(screenshot_path)
-        return True
+        return True, screenshot_path
 
     def emulate(self) -> None:
         stop = Event()

--- a/test.py
+++ b/test.py
@@ -33,7 +33,7 @@ def run_test(test_rom_path: str,
     time.sleep(wait_seconds)
     stop.set()
     # test
-    _, screenshot_path = emu.capture_screenshot()
+    _, screenshot_path = emu.capture_screenshot(screenshot_path)
     assert _run_ocr(screenshot_path) == expect_output, error_message
     print(f'{test_rom_path} PASSED')
     # clean

--- a/test.py
+++ b/test.py
@@ -1,0 +1,41 @@
+import time
+import os
+import easyocr
+from gui import Emulator
+from console import Console
+from threading import Thread, Event
+
+
+reader = easyocr.Reader(['en'])
+
+def _run_ocr(filename: str) -> str:
+    with open(filename, 'rb') as file:
+        image = file.read()
+    results = reader.readtext(image)
+    words = [result[1] for result in results]
+    return " ".join(words)
+
+emu = Emulator()
+
+def run_test(test_rom_path: str,
+             expect_output: str,
+             error_message: str,
+             wait_seconds: int = 2,
+             screenshot_path: str = None,
+             keep_screenshot: bool = True) -> None:
+    # launch emulator
+    emu.console = Console(test_rom_path)
+    emu.console.power_up()
+    # run
+    stop = Event()
+    async_run = Thread(target=emu.run, args=(stop,))
+    async_run.start()
+    time.sleep(wait_seconds)
+    stop.set()
+    # test
+    _, screenshot_path = emu.capture_screenshot()
+    assert _run_ocr(screenshot_path) == expect_output, error_message
+    print(f'{test_rom_path} PASSED')
+    # clean
+    if not keep_screenshot:
+        os.remove(screenshot_path)


### PR DESCRIPTION
# Support test automation
## Usage
[![screenshot.png](https://iili.io/d9CdEWg.md.png)](https://freeimage.host/i/d9CdEWg)

Use `run_test` to test specific rom, screenshots saved in `./screenshots`

* Basic Usage: `test rom path`, `expect output`, `error message`
* Advanced Usage: override `wait seconds`, `screenshot path`, `keep screenshot`  